### PR TITLE
Updates jekyll-action to latest version.

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
-      - uses: helaili/jekyll-action@2.0.0
+      - uses: helaili/jekyll-action@2.0.2
         env:
           JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}


### PR DESCRIPTION
In version 2.0.2 it is possible to publish to master branch, this is required for user pages.