### PR TITLE
Upgrade runner ubuntu version (16 -> 20)

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
# Problem

I used your template and my actions failed because of this. 
I saw your pipeline was failing too, maybe this will fix it !

# Solution

Ask the jekyll runner to use ubuntu 20 and not ubuntu 16. As far as I undestood, since ubuntu 16 is no longer maintened, there is no more available runner matching our criterion.

